### PR TITLE
refactor: Simplify WebRTC Context State Management

### DIFF
--- a/src/app/components/Chat.tsx
+++ b/src/app/components/Chat.tsx
@@ -256,42 +256,6 @@ const Chat: React.FC = () => {
           </div>
         )}
 
-        {/* Error Section */}
-        {session?.errors && session.errors.length > 0 && (
-          <div className="border-t pt-4">
-            <h2 className="text-lg font-bold text-red-600">Errors</h2>
-            <div className="overflow-y-auto max-h-32 border rounded p-4 bg-red-50">
-              {session.errors.map((error, index) => (
-                <div key={index} className="mb-2">
-                  <p className="text-sm text-red-800">
-                    <strong>Error Type:</strong> {error.type}
-                  </p>
-                  {error.message && (
-                    <p className="text-sm text-red-700">
-                      <strong>Message:</strong> {error.message}
-                    </p>
-                  )}
-                  {error.code && (
-                    <p className="text-sm text-red-700">
-                      <strong>Code:</strong> {error.code}
-                    </p>
-                  )}
-                  {error.param && (
-                    <p className="text-sm text-red-700">
-                      <strong>Param:</strong> {error.param}
-                    </p>
-                  )}
-                  <p className="text-xs text-gray-500">
-                    <strong>Event ID:</strong> {error.event_id} |{' '}
-                    <strong>Timestamp:</strong>{' '}
-                    {new Date(error.timestamp).toLocaleString()}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
         {/* Transcripts */}
         {session?.transcripts && session.transcripts.length > 0 && (
           <Transcripts transcripts={session.transcripts} />

--- a/src/app/components/Chat.tsx
+++ b/src/app/components/Chat.tsx
@@ -13,6 +13,7 @@ import {
   RealtimeEventType,
   Voice,
   OpenAICreateSessionParams,
+  ConnectionStatus,
 } from '../types';
 import tools from './openAITools';
 import Transcripts from './Transcripts';
@@ -63,14 +64,14 @@ const Chat: React.FC = () => {
   });
 
   const {
-    startSession,
+    connect,
     sendClientEvent,
-    closeSession,
+    disconnect,
     session,
     sendAudioChunk,
     commitAudioBuffer,
-    createResponse,
     sendTextMessage,
+    createResponse,
     muteSessionAudio,
     unmuteSessionAudio,
   } = useSession();
@@ -90,7 +91,7 @@ const Chat: React.FC = () => {
   async function onSessionStart() {
     const { connection_timeout, ...rest } = config;
     const newSession = await createNewOpenAISession(rest);
-    startSession({ ...newSession, connection_timeout }, handleFunctionCall);
+    connect({ ...newSession, connection_timeout }, handleFunctionCall);
   }
 
   const handleModeChange = (newMode: 'vad' | 'push-to-talk') => {
@@ -102,7 +103,7 @@ const Chat: React.FC = () => {
     };
     setConfig(updatedConfig);
 
-    if (session?.isConnected) {
+    if (session?.connectionStatus === ConnectionStatus.CONNECTED) {
       sendClientEvent({
         type: RealtimeEventType.SESSION_UPDATE,
         session: {
@@ -121,7 +122,7 @@ const Chat: React.FC = () => {
     setConfig(updatedConfig);
 
     // If session is active, update it
-    if (session?.isConnected) {
+    if (session?.connectionStatus === ConnectionStatus.CONNECTED) {
       sendClientEvent({
         type: RealtimeEventType.SESSION_UPDATE,
         session: {
@@ -180,9 +181,9 @@ const Chat: React.FC = () => {
           <h1 className="text-xl font-bold text-gray-800">AI Chat</h1>
 
           {/* Session Control */}
-          {session?.isConnected ? (
+          {session?.connectionStatus === ConnectionStatus.CONNECTED ? (
             <button
-              onClick={() => closeSession()}
+              onClick={() => disconnect()}
               className="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600"
             >
               End Session

--- a/src/app/components/Chat.tsx
+++ b/src/app/components/Chat.tsx
@@ -174,7 +174,6 @@ const Chat: React.FC = () => {
 
   return (
     <div className="w-full max-w-2xl mx-auto p-4 bg-white rounded-lg shadow-lg space-y-6">
-      <SessionsDebugger />
       {/* Header Section */}
       <div className="space-y-4">
         <div className="flex justify-between items-center">
@@ -292,6 +291,7 @@ const Chat: React.FC = () => {
             />
           )}
         </div>
+        <SessionsDebugger />
       </div>
     </div>
   );

--- a/src/app/components/SessionsDebugger.tsx
+++ b/src/app/components/SessionsDebugger.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import React from 'react';
-import { useOpenAIRealtimeWebRTC } from '../context/OpenAIRealtimeWebRTC';
+import { useSession } from '../context/OpenAIRealtimeWebRTC';
 import { JsonViewer } from '@textea/json-viewer';
+import { ConnectionStatus } from '../types';
 
 const SessionsDebugger: React.FC = () => {
-  const { sessions } = useOpenAIRealtimeWebRTC();
+  const { session } = useSession();
 
-  if (sessions.length === 0) {
+  if (!session) {
     return (
       <div className="p-4 bg-gray-50 rounded-lg">
         <p className="text-gray-500">No active sessions</p>
@@ -17,39 +18,37 @@ const SessionsDebugger: React.FC = () => {
 
   return (
     <div className="p-4 bg-white rounded-lg shadow">
-      <h2 className="text-lg font-bold mb-4">
-        Sessions Debugger ({sessions.length})
-      </h2>
+      <h2 className="text-lg font-bold mb-4">Sessions Debugger</h2>
       <div className="space-y-4">
-        {sessions.map((session) => (
-          <div key={session.id} className="border rounded-lg p-4 bg-gray-50">
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="font-medium">Session ID: {session.id}</h3>
-              <span
-                className={`px-2 py-1 rounded-full text-sm ${
-                  session.isConnected
-                    ? 'bg-green-100 text-green-800'
-                    : 'bg-red-100 text-red-800'
-                }`}
-              >
-                {session.isConnected ? 'Connected' : 'Disconnected'}
-              </span>
-            </div>
-            <div className="mt-2 overflow-auto max-h-96">
-              <JsonViewer
-                value={session}
-                defaultInspectDepth={2}
-                theme="light"
-                displayDataTypes={false}
-                enableClipboard={true}
-                style={{
-                  backgroundColor: 'transparent',
-                  padding: '8px',
-                }}
-              />
-            </div>
+        <div key={session.id} className="border rounded-lg p-4 bg-gray-50">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="font-medium">Session ID: {session.id}</h3>
+            <span
+              className={`px-2 py-1 rounded-full text-sm ${
+                session.connectionStatus === ConnectionStatus.CONNECTED
+                  ? 'bg-green-100 text-green-800'
+                  : 'bg-red-100 text-red-800'
+              }`}
+            >
+              {session.connectionStatus === ConnectionStatus.CONNECTED
+                ? 'Connected'
+                : 'Disconnected'}
+            </span>
           </div>
-        ))}
+          <div className="mt-2 overflow-auto max-h-96">
+            <JsonViewer
+              value={session}
+              defaultInspectDepth={2}
+              theme="light"
+              displayDataTypes={false}
+              enableClipboard={true}
+              style={{
+                backgroundColor: 'transparent',
+                padding: '8px',
+              }}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/app/context/OpenAIRealtimeWebRTC.tsx
+++ b/src/app/context/OpenAIRealtimeWebRTC.tsx
@@ -4,8 +4,8 @@ import React, {
   createContext,
   useContext,
   useReducer,
-  useState,
   useEffect,
+  useCallback,
 } from 'react';
 import {
   Transcript,
@@ -24,13 +24,13 @@ import {
   ResponseOutputItemDoneEvent,
   TokenUsage,
   ResponseDoneEvent,
-  StartSession,
   Modality,
   SessionCloseOptions,
   ConnectionStatus,
   RateLimit,
   RateLimitsUpdatedEvent,
   OpenAIRealtimeWebRTCProviderProps,
+  Connect,
 } from '../types';
 import { createNoopLogger } from '../utils/logger';
 
@@ -41,83 +41,65 @@ interface OpenAIRealtimeWebRTCContextType {
   /**
    * Gets the list of all active sessions.
    */
-  sessions: RealtimeSession[];
-
-  /**
-   * Retrieves the state of a specific session by its ID.
-   *
-   * @param sessionId - The unique identifier for the session.
-   * @returns The session object if found, otherwise `null`.
-   */
-  getSessionById: (sessionId: string) => RealtimeSession | null;
+  session: RealtimeSession | null;
 
   /**
    * Starts a new WebRTC session with the OpenAI API.
-   *
-   * @param sessionId - The unique identifier for the new session.
    * @param realtimeSession - The session object containing configuration.
    * @returns A promise that resolves once the session is successfully started.
    */
-  startSession: StartSession;
+  connect: Connect;
 
   /**
    * Ends an active WebRTC session and cleans up its resources.
    *
-   * @param sessionId - The unique identifier for the session to close.
    * @param options - Configuration options for closing behavior.
    * @param options.removeAfterConnectionClose - Whether to remove the session from state after closing. Defaults to true.
    */
-  closeSession: (sessionId: string, options?: SessionCloseOptions) => void;
+  disconnect: () => void;
 
   /**
    * Sends a text message to a specific session.
    *
-   * @param sessionId - The unique identifier for the session to send the message to.
    * @param message - The text message content.
    */
-  sendTextMessage: (sessionId: string, message: string) => void;
+  sendTextMessage: (message: string) => void;
 
   /**
    * Sends a custom client event to a specific session.
    *
-   * @param sessionId - The unique identifier for the session to send the event to.
    * @param event - The custom event payload.
    */
-  sendClientEvent: (sessionId: string, event: RealtimeEvent) => void;
+  sendClientEvent: (event: RealtimeEvent) => void;
 
   /**
    * Sends an audio chunk to a specific session for processing.
    *
-   * @param sessionId - The unique identifier for the session to send the audio to.
    * @param audioData - The Base64-encoded audio chunk to be sent.
    */
-  sendAudioChunk: (sessionId: string, audioData: string) => void;
+  sendAudioChunk: (audioData: string) => void;
 
   /**
    * Commits the audio buffer for processing in a specific session.
    *
-   * @param sessionId - The unique identifier for the session to commit the audio buffer for.
    */
-  commitAudioBuffer: (sessionId: string) => void;
+  commitAudioBuffer: () => void;
 
   /**
    * Creates a new response for a specific session.
-   * @param sessionId - The unique identifier for the session to send the response to.
    * @param response - The response object to be sent.
    */
-  createResponse: (sessionId: string, response?: ResponseCreateBody) => void;
+  createResponse: (response?: ResponseCreateBody) => void;
 
   /**
    * Mutes the audio for a specific session.
-   * @param sessionId - The unique identifier for the session to mute.
    */
-  muteSessionAudio: (sessionId: string) => void;
+  muteSessionAudio: () => void;
 
   /**
    * Unmutes the audio for a specific session.
-   * @param sessionId - The unique identifier for the session to unmute.
    */
-  unmuteSessionAudio: (sessionId: string) => void;
+  unmuteSessionAudio: () => void;
 }
 
 // Create the OpenAI Realtime WebRTC context
@@ -126,11 +108,11 @@ const OpenAIRealtimeWebRTCContext = createContext<
 >(undefined);
 
 // Export the context for use in other components
-export const useOpenAIRealtimeWebRTC = (): OpenAIRealtimeWebRTCContextType => {
+export const useSession = (): OpenAIRealtimeWebRTCContextType => {
   const context = useContext(OpenAIRealtimeWebRTCContext);
   if (!context) {
     throw new Error(
-      'useOpenAIRealtimeWebRTC must be used within an OpenAIRealtimeWebRTCProvider'
+      'useSession must be used within an OpenAIRealtimeWebRTCProvider'
     );
   }
   return context;
@@ -138,68 +120,46 @@ export const useOpenAIRealtimeWebRTC = (): OpenAIRealtimeWebRTCContextType => {
 
 // Enum for action types to avoid hardcoding strings
 export enum SessionActionType {
-  ADD_SESSION = 'ADD_SESSION',
-  REMOVE_SESSION = 'REMOVE_SESSION',
+  INIT_SESSION = 'INIT_SESSION',
   UPDATE_SESSION = 'UPDATE_SESSION',
   ADD_TRANSCRIPT = 'ADD_TRANSCRIPT',
-  SET_FUNCTION_CALL_HANDLER = 'SET_FUNCTION_CALL_HANDLER',
   UPDATE_TOKEN_USAGE = 'UPDATE_TOKEN_USAGE',
   MUTE_SESSION_AUDIO = 'MUTE_SESSION_AUDIO',
   UNMUTE_SESSION_AUDIO = 'UNMUTE_SESSION_AUDIO',
   UPDATE_RATE_LIMITS = 'UPDATE_RATE_LIMITS',
 }
 
-// Action interfaces for type safety
-interface AddSessionAction {
-  type: SessionActionType.ADD_SESSION;
+interface InitSessionAction {
+  type: SessionActionType.INIT_SESSION;
   payload: RealtimeSession;
-}
-
-interface RemoveSessionAction {
-  type: SessionActionType.REMOVE_SESSION;
-  payload: { id: string }; // Only the channel ID is needed to remove
 }
 
 interface UpdateSessionAction {
   type: SessionActionType.UPDATE_SESSION;
-  payload: Partial<RealtimeSession> & { id: string }; // Allow partial updates, must include `id`
+  payload: Partial<RealtimeSession>;
 }
 
 interface AddTranscriptAction {
   type: SessionActionType.ADD_TRANSCRIPT;
-  payload: { sessionId: string; transcript: Transcript };
-}
-
-interface SetFunctionCallHandlerAction {
-  type: SessionActionType.SET_FUNCTION_CALL_HANDLER;
-  payload: {
-    sessionId: string;
-    onFunctionCall: (name: string, args: Record<string, unknown>) => void;
-  };
+  payload: { transcript: Transcript };
 }
 
 interface UpdateTokenUsageAction {
   type: SessionActionType.UPDATE_TOKEN_USAGE;
-  /**
-   * Payload containing the session ID and new token usage data.
-   */
-  payload: { sessionId: string; tokenUsage: TokenUsage };
+  payload: { tokenUsage: TokenUsage };
 }
 
 interface MuteSessionAudioAction {
   type: SessionActionType.MUTE_SESSION_AUDIO;
-  payload: { sessionId: string };
 }
 
 interface UnmuteSessionAudioAction {
   type: SessionActionType.UNMUTE_SESSION_AUDIO;
-  payload: { sessionId: string };
 }
 
 interface UpdateRateLimitsAction {
   type: SessionActionType.UPDATE_RATE_LIMITS;
   payload: {
-    sessionId: string;
     rateLimits: RateLimit[];
     rateLimitResetTime: string;
     isRateLimited: boolean;
@@ -208,173 +168,70 @@ interface UpdateRateLimitsAction {
 
 // Union type for all actions
 type SessionAction =
-  | AddSessionAction
-  | RemoveSessionAction
+  | InitSessionAction
   | UpdateSessionAction
   | AddTranscriptAction
-  | SetFunctionCallHandlerAction
   | UpdateTokenUsageAction
   | MuteSessionAudioAction
   | UnmuteSessionAudioAction
   | UpdateRateLimitsAction;
 
-// Reducer state type
-type ChannelState = RealtimeSession[];
-
 // Reducer function
 export const sessionReducer = (
-  state: ChannelState,
+  state: RealtimeSession | null,
   action: SessionAction
-): ChannelState => {
+): RealtimeSession | null => {
   switch (action.type) {
-    case SessionActionType.ADD_SESSION:
-      return [...state, action.payload]; // Add a new session to the state
-
-    case SessionActionType.REMOVE_SESSION:
-      return state.filter((session) => session.id !== action.payload.id); // Remove session by ID
-
+    case SessionActionType.INIT_SESSION:
+      return action.payload;
     case SessionActionType.UPDATE_SESSION:
-      return state.map((session) =>
-        session.id === action.payload.id
-          ? { ...session, ...action.payload } // Merge updates with existing session
-          : session
-      );
+      if (!state) {
+        return null;
+      }
+      return { ...state, ...action.payload };
     case SessionActionType.ADD_TRANSCRIPT:
-      return state.map((session) =>
-        session.id === action.payload.sessionId
-          ? {
-              ...session,
-              transcripts: [
-                ...(session.transcripts || []),
-                action.payload.transcript,
-              ],
-            }
-          : session
-      );
-    case SessionActionType.SET_FUNCTION_CALL_HANDLER:
-      return state.map((session) =>
-        session.id === action.payload.sessionId
-          ? { ...session, onFunctionCall: action.payload.onFunctionCall }
-          : session
-      );
+      if (!state) {
+        return null;
+      }
+      return {
+        ...state,
+        transcripts: [...(state?.transcripts || []), action.payload.transcript],
+      };
     case SessionActionType.UPDATE_TOKEN_USAGE:
-      return state.map((session) =>
-        session.id === action.payload.sessionId
-          ? { ...session, tokenUsage: action.payload.tokenUsage }
-          : session
-      );
+      if (!state) {
+        return null;
+      }
+      return { ...state, tokenUsage: action.payload.tokenUsage };
     case SessionActionType.MUTE_SESSION_AUDIO:
-      return state.map((session) =>
-        session.id === action.payload.sessionId
-          ? { ...session, isMuted: true }
-          : session
-      );
+      if (!state) {
+        return null;
+      }
+      return { ...state, isMuted: true };
     case SessionActionType.UNMUTE_SESSION_AUDIO:
-      return state.map((session) =>
-        session.id === action.payload.sessionId
-          ? { ...session, isMuted: false }
-          : session
-      );
+      if (!state) {
+        return null;
+      }
+      return { ...state, isMuted: false };
     case SessionActionType.UPDATE_RATE_LIMITS:
-      return state.map((session) =>
-        session.id === action.payload.sessionId
-          ? {
-              ...session,
-              rateLimits: action.payload.rateLimits,
-              rateLimitResetTime: action.payload.rateLimitResetTime,
-              isRateLimited: action.payload.isRateLimited,
-            }
-          : session
-      );
-
+      if (!state) {
+        return null;
+      }
+      return {
+        ...state,
+        rateLimits: action.payload.rateLimits,
+        rateLimitResetTime: action.payload.rateLimitResetTime,
+        isRateLimited: action.payload.isRateLimited,
+      };
     default:
       // Ensure exhaustive checks in TypeScript
       throw new Error(`Unhandled action type: ${action}`);
   }
 };
 
-export const useSession = (id?: string | undefined) => {
-  const [sessionId, setSessionId] = useState<string | undefined>(id);
-  const {
-    getSessionById,
-    closeSession,
-    sendTextMessage,
-    sendClientEvent,
-    sendAudioChunk,
-    commitAudioBuffer,
-    createResponse,
-    startSession,
-    muteSessionAudio,
-    unmuteSessionAudio,
-  } = useOpenAIRealtimeWebRTC();
-
-  const handleStartSession: StartSession = async (
-    newSession: RealtimeSession,
-    ...rest
-  ) => {
-    await startSession(newSession, ...rest);
-    setSessionId(newSession.id);
-  };
-
-  const session = sessionId ? getSessionById(sessionId) : undefined;
-
-  if (!session || !sessionId) {
-    return {
-      session,
-      startSession: (newSession: RealtimeSession) =>
-        handleStartSession(newSession),
-      closeSession: () => {
-        throw new Error('Session not started');
-      },
-      sendTextMessage: () => {
-        throw new Error('Session not started');
-      },
-      sendClientEvent: () => {
-        throw new Error('Session not started');
-      },
-      sendAudioChunk: () => {
-        throw new Error('Session not started');
-      },
-      commitAudioBuffer: () => {
-        throw new Error('Session not started');
-      },
-      createResponse: () => {
-        throw new Error('Session not started');
-      },
-      muteSessionAudio: () => {
-        throw new Error('Session not started');
-      },
-      unmuteSessionAudio: () => {
-        throw new Error('Session not started');
-      },
-    };
-  }
-
-  return {
-    session,
-    closeSession: (options?: SessionCloseOptions) =>
-      closeSession(sessionId, options),
-    sendTextMessage: (message: string) => sendTextMessage(sessionId, message),
-    sendClientEvent: (event: RealtimeEvent) =>
-      sendClientEvent(sessionId, event),
-    sendAudioChunk: (audioData: string) => sendAudioChunk(sessionId, audioData),
-    commitAudioBuffer: () => commitAudioBuffer(sessionId),
-    createResponse: (response?: ResponseCreateBody) =>
-      createResponse(sessionId, response),
-    startSession: startSession,
-    muteSessionAudio: () => {
-      muteSessionAudio(sessionId);
-    },
-    unmuteSessionAudio: () => {
-      unmuteSessionAudio(sessionId);
-    },
-  };
-};
-
 export const OpenAIRealtimeWebRTCProvider: React.FC<
   OpenAIRealtimeWebRTCProviderProps
 > = ({ config, children }) => {
-  const [sessions, dispatch] = useReducer(sessionReducer, []);
+  const [session, dispatch] = useReducer(sessionReducer, null);
 
   const logger = config.logger || createNoopLogger();
 
@@ -390,18 +247,16 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
     };
   }, [config, logger]);
 
-  // get session by id
-  const getSessionById = (sessionId: string): RealtimeSession | null => {
-    return sessions.find((session) => session.id === sessionId) || null;
-  };
-
-  const startSession: StartSession = async (
+  const connect: Connect = async (
     realtimeSession: RealtimeSession,
     functionCallHandler?: (name: string, args: Record<string, unknown>) => void
   ): Promise<void> => {
     const sessionId = realtimeSession.id;
     let iceTimeoutId: NodeJS.Timeout | null = null;
-
+    dispatch({
+      type: SessionActionType.INIT_SESSION,
+      payload: realtimeSession,
+    });
     try {
       const pc = new RTCPeerConnection({
         iceServers: [], // OpenAI handles this
@@ -509,8 +364,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
             type: SessionActionType.UPDATE_SESSION,
             payload: {
               id: sessionId,
-              isConnecting: false,
-              isConnected: true,
               connectionStatus: ConnectionStatus.CONNECTED,
               lastStateChange: new Date().toISOString(),
             },
@@ -529,7 +382,7 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
         if (pc.iceConnectionState !== 'connected') {
           logger.error(`ICE connection timeout for session '${sessionId}'`);
           // handle timeout
-          cleanupWebRTCResources(getSessionById(sessionId));
+          cleanupWebRTCResources();
         }
       }, iceTimeout);
 
@@ -547,9 +400,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
               dispatch({
                 type: SessionActionType.UPDATE_SESSION,
                 payload: {
-                  id: sessionId,
-                  isConnecting: true,
-                  isConnected: false,
                   connectionStatus: ConnectionStatus.CONNECTING,
                   lastStateChange: new Date().toISOString(),
                 },
@@ -565,7 +415,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
               dispatch({
                 type: SessionActionType.UPDATE_SESSION,
                 payload: {
-                  id: sessionId,
                   connectionStatus: ConnectionStatus.CONNECTED,
                   lastStateChange: new Date().toISOString(),
                 },
@@ -576,7 +425,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
               dispatch({
                 type: SessionActionType.UPDATE_SESSION,
                 payload: {
-                  id: sessionId,
                   connectionStatus: ConnectionStatus.DISCONNECTED,
                   lastStateChange: new Date().toISOString(),
                 },
@@ -589,7 +437,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
                 dispatch({
                   type: SessionActionType.UPDATE_SESSION,
                   payload: {
-                    id: sessionId,
                     connectionStatus: ConnectionStatus.RECONNECTING, // using enum value here
                     lastStateChange: new Date().toISOString(),
                   },
@@ -606,12 +453,11 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
               dispatch({
                 type: SessionActionType.UPDATE_SESSION,
                 payload: {
-                  id: sessionId,
                   connectionStatus: ConnectionStatus.FAILED,
                   lastStateChange: new Date().toISOString(),
                 },
               });
-              cleanupWebRTCResources(getSessionById(sessionId));
+              cleanupWebRTCResources();
               break;
 
             case 'closed':
@@ -622,12 +468,11 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
               dispatch({
                 type: SessionActionType.UPDATE_SESSION,
                 payload: {
-                  id: sessionId,
                   connectionStatus: ConnectionStatus.CLOSED,
                   lastStateChange: new Date().toISOString(),
                 },
               });
-              cleanupWebRTCResources(getSessionById(sessionId));
+              cleanupWebRTCResources();
               break;
 
             default:
@@ -639,7 +484,7 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
         // Set ICE connection timeout remains as before
         iceTimeoutId = setTimeout(() => {
           logger.error(`ICE connection timeout for session '${sessionId}'`);
-          cleanupWebRTCResources(getSessionById(sessionId));
+          cleanupWebRTCResources();
         }, 30000); // 30 second timeout
       };
 
@@ -648,20 +493,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
 
       // Create data channel
       const dc = pc.createDataChannel(sessionId);
-
-      // Add session to state
-      dispatch({
-        type: SessionActionType.ADD_SESSION,
-        payload: {
-          ...realtimeSession,
-          peer_connection: pc,
-          dataChannel: dc,
-          tokenRef: realtimeSession?.client_secret?.value,
-          isConnecting: true,
-          isConnected: false,
-          startTime: new Date().toISOString(),
-        } as RealtimeSession,
-      });
 
       pc.onnegotiationneeded = async () => {
         try {
@@ -720,16 +551,14 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
       pc.ontrack = (event) => {
         logger.info(`Remote stream received for session '${sessionId}'.`);
         event.track.onended = () => {
-          const session = getSessionById(sessionId);
           if (session) {
-            cleanupWebRTCResources(session);
+            cleanupWebRTCResources();
           }
         };
 
         dispatch({
           type: SessionActionType.UPDATE_SESSION,
           payload: {
-            id: sessionId,
             mediaStream: event.streams[0],
           },
         });
@@ -740,11 +569,10 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
         dispatch({
           type: SessionActionType.UPDATE_SESSION,
           payload: {
-            id: sessionId,
-            isConnecting: false,
-            isConnected: true,
-          } as RealtimeSession,
+            connectionStatus: ConnectionStatus.CONNECTED,
+          },
         });
+
         logger.info(`Data channel for session '${sessionId}' is open.`);
       });
 
@@ -765,7 +593,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
             dispatch({
               type: SessionActionType.ADD_TRANSCRIPT,
               payload: {
-                sessionId,
                 transcript: {
                   content: event.transcript,
                   timestamp: Date.now(),
@@ -783,7 +610,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
             dispatch({
               type: SessionActionType.ADD_TRANSCRIPT,
               payload: {
-                sessionId,
                 transcript: {
                   content: event.transcript,
                   timestamp: Date.now(),
@@ -814,7 +640,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
               dispatch({
                 type: SessionActionType.UPDATE_TOKEN_USAGE,
                 payload: {
-                  sessionId,
                   tokenUsage: {
                     inputTokens: usage.input_tokens,
                     outputTokens: usage.output_tokens,
@@ -841,7 +666,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
             dispatch({
               type: SessionActionType.UPDATE_RATE_LIMITS,
               payload: {
-                sessionId,
                 rateLimits: rateLimitsEvent.rate_limits,
                 rateLimitResetTime: resetTime,
                 isRateLimited,
@@ -861,10 +685,7 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
 
       dc.addEventListener('close', () => {
         logger.info(`Session '${sessionId}' closed.`);
-        dispatch({
-          type: SessionActionType.REMOVE_SESSION,
-          payload: { id: sessionId },
-        });
+        disconnect();
       });
     } catch (error: unknown) {
       logger.error(`Failed to start session '${sessionId}':`, {
@@ -884,18 +705,15 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
    *
    * @param sessionId - The unique identifier of the session to close.
    */
-  const closeSession = (
-    sessionId: string,
+  const disconnect = (
     options: SessionCloseOptions = { removeAfterConnectionClose: true }
   ): void => {
-    const session = getSessionById(sessionId);
     if (!session) {
-      logger.warn(`Session with ID '${sessionId}' does not exist.`);
       return;
     }
 
-    cleanupWebRTCResources(session);
-
+    cleanupWebRTCResources();
+    const sessionId = session.id;
     const endTime = new Date().toISOString();
     const startTimeMs = session.startTime
       ? new Date(session.startTime).getTime()
@@ -907,21 +725,11 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
     dispatch({
       type: SessionActionType.UPDATE_SESSION,
       payload: {
-        id: sessionId,
-        isConnecting: false,
-        isConnected: false,
+        connectionStatus: ConnectionStatus.CLOSED,
         endTime,
         duration,
       },
     });
-
-    // Only remove the session if explicitly requested
-    if (options.removeAfterConnectionClose) {
-      dispatch({
-        type: SessionActionType.REMOVE_SESSION,
-        payload: { id: sessionId },
-      });
-    }
 
     logger.info(
       `Session '${sessionId}' connection closed. Duration: ${duration}s. Session ${
@@ -936,16 +744,13 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
    * @param sessionId - The unique identifier of the session to send the event to.
    * @param event - The event object to be sent.
    */
-  const sendClientEvent = (sessionId: string, event: RealtimeEvent): void => {
-    // Find the session by ID
-    const session = sessions.find((s) => s.id === sessionId);
-
+  const sendClientEvent = (event: RealtimeEvent): void => {
     if (!session) {
-      logger.error(`Session with ID '${sessionId}' does not exist.`);
       return;
     }
 
     const { dataChannel } = session;
+    const sessionId = session.id;
 
     // Ensure the data channel is open before sending the event
     if (!dataChannel || dataChannel.readyState !== 'open') {
@@ -975,11 +780,9 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
 
   /**
    * Sends a text message to a specific WebRTC session.
-   *
-   * @param sessionId - The unique identifier of the session to send the message to.
    * @param message - The text message to be sent.
    */
-  const sendTextMessage = (sessionId: string, message: string): void => {
+  const sendTextMessage = (message: string): void => {
     // Create the conversation item creation event
     const userEvent: ConversationItemCreateEvent = {
       type: RealtimeEventType.CONVERSATION_ITEM_CREATE,
@@ -997,18 +800,14 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
     };
 
     // Send the user message event
-    sendClientEvent(sessionId, userEvent);
+    sendClientEvent(userEvent);
   };
 
   /**
    * Creates a new response - Typically used for non VAD sessions.
-   * @param sessionId - The unique identifier of the session to send the response to.
    * @param response - The response object to be sent.
    */
-  const createResponse = (
-    sessionId: string,
-    response: ResponseCreateBody = {}
-  ): void => {
+  const createResponse = (response: ResponseCreateBody = {}): void => {
     // Create the response creation event
     const responseEvent: ResponseCreateEvent = {
       type: RealtimeEventType.RESPONSE_CREATE,
@@ -1017,7 +816,7 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
     };
 
     // Send the response creation event
-    sendClientEvent(sessionId, responseEvent);
+    sendClientEvent(responseEvent);
   };
 
   /**
@@ -1026,48 +825,45 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
    * @param sessionId - The unique identifier of the session to send the audio to.
    * @param audioData - The Base64-encoded audio chunk to be sent.
    */
-  const sendAudioChunk = (sessionId: string, audioData: string): void => {
+  const sendAudioChunk = (audioData: string): void => {
     const audioChunkEvent: InputAudioBufferAppendEvent = {
       type: RealtimeEventType.INPUT_AUDIO_BUFFER_APPEND,
       event_id: crypto.randomUUID(), // Generate a unique event ID
       audio: audioData,
     };
 
-    sendClientEvent(sessionId, audioChunkEvent);
+    sendClientEvent(audioChunkEvent);
   };
 
   /**
    * Commits the audio buffer for processing in a specific WebRTC session.
    *
-   * @param sessionId - The unique identifier of the session to commit the audio buffer for.
    */
-  const commitAudioBuffer = (sessionId: string): void => {
+  const commitAudioBuffer = (): void => {
     const commitEvent: InputAudioBufferCommitEvent = {
       type: RealtimeEventType.INPUT_AUDIO_BUFFER_COMMIT,
       event_id: crypto.randomUUID(), // Generate a unique event ID
     };
 
-    sendClientEvent(sessionId, commitEvent);
+    sendClientEvent(commitEvent);
   };
 
-  const muteSessionAudio = (sessionId: string): void => {
+  const muteSessionAudio = (): void => {
     dispatch({
       type: SessionActionType.MUTE_SESSION_AUDIO,
-      payload: { sessionId },
     });
   };
 
-  const unmuteSessionAudio = (sessionId: string): void => {
+  const unmuteSessionAudio = (): void => {
     dispatch({
       type: SessionActionType.UNMUTE_SESSION_AUDIO,
-      payload: { sessionId },
     });
   };
 
   /**
    * Utility function to properly cleanup WebRTC resources
    */
-  const cleanupWebRTCResources = (session: RealtimeSession | null) => {
+  const cleanupWebRTCResources = useCallback(() => {
     if (!session) return;
 
     // Cleanup media tracks
@@ -1108,29 +904,26 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
     session.mediaStream = null;
     session.dataChannel = null;
     session.peer_connection = null;
-  };
+  }, [session]);
 
   // Handle cleanup on page unload
   useEffect(() => {
     const handleBeforeUnload = () => {
-      sessions.forEach((session) => {
-        cleanupWebRTCResources(session);
-      });
+      cleanupWebRTCResources();
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [sessions]);
+  }, [session, cleanupWebRTCResources]);
 
   return (
     <OpenAIRealtimeWebRTCContext.Provider
       value={{
-        sessions,
-        getSessionById,
-        startSession,
-        closeSession,
+        session,
+        connect,
+        disconnect,
         sendTextMessage,
         sendClientEvent,
         sendAudioChunk,

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -895,12 +895,6 @@ export interface RealtimeSession {
    * Each transcript includes details such as content, timestamp, type, and role.
    */
   transcripts: Transcript[];
-
-  /**
-   * List of errors that have occurred during this session.
-   * This array is updated whenever an error event is received.
-   */
-  errors?: SessionError[];
   /**
    * Tracks token usage statistics for the session.
    */

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -876,16 +876,6 @@ export interface RealtimeSession {
   dataChannel?: RTCDataChannel | null;
 
   /**
-   * Indicates whether the session is in the process of being established.
-   */
-  isConnecting?: boolean;
-
-  /**
-   * Indicates whether the session is successfully connected and ready for use.
-   */
-  isConnected?: boolean;
-
-  /**
    * The local media stream used for audio output.
    */
   mediaStream?: MediaStream | null;
@@ -1108,7 +1098,7 @@ export type FunctionCallHandler = (
   args: Record<string, unknown>
 ) => void;
 
-export type StartSession = (
+export type Connect = (
   realtimeSession: RealtimeSession,
   functionCallHandler?: FunctionCallHandler
 ) => void;


### PR DESCRIPTION
This PR simplifies the WebRTC context state management by:

- Converting from multi-session to single-session management
- Replacing `isConnected`/`isConnecting` with unified `connectionStatus` enum
- Removing redundant state properties and error handling
- Updating component interfaces to remove session ID parameters
- Simplifying the reducer and context API

Breaking Changes:
- Renamed `startSession` to `connect` and `closeSession` to `disconnect`
- Removed multi-session support
- Updated all method signatures to remove sessionId parameter