### PR TITLE
feat(audio)!: remove audio control from WebRTC context

### DIFF
--- a/src/app/components/Chat.tsx
+++ b/src/app/components/Chat.tsx
@@ -72,8 +72,6 @@ const Chat: React.FC = () => {
     commitAudioBuffer,
     sendTextMessage,
     createResponse,
-    muteSessionAudio,
-    unmuteSessionAudio,
   } = useSession();
 
   async function createNewOpenAISession(
@@ -247,12 +245,7 @@ const Chat: React.FC = () => {
         {/* WebRTC Player */}
         {session?.mediaStream && (
           <div className="border-t pt-4">
-            <WebRTCPlayer
-              remoteStream={session.mediaStream}
-              isMuted={session.isMuted ?? false}
-              onMute={muteSessionAudio}
-              onUnmute={unmuteSessionAudio}
-            />
+            <WebRTCPlayer remoteStream={session.mediaStream} />
           </div>
         )}
 

--- a/src/app/components/WebRTCPlayer.tsx
+++ b/src/app/components/WebRTCPlayer.tsx
@@ -4,17 +4,9 @@ import React, { useEffect, useRef } from 'react';
 
 interface WebRTCPlayerProps {
   remoteStream: MediaStream | null;
-  isMuted: boolean;
-  onMute: () => void;
-  onUnmute: () => void;
 }
 
-const WebRTCPlayer: React.FC<WebRTCPlayerProps> = ({
-  remoteStream,
-  isMuted,
-  onMute,
-  onUnmute,
-}) => {
+const WebRTCPlayer: React.FC<WebRTCPlayerProps> = ({ remoteStream }) => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
@@ -81,28 +73,14 @@ const WebRTCPlayer: React.FC<WebRTCPlayerProps> = ({
     }
   }, [remoteStream]);
 
-  const handleMuteClick = () => {
-    if (isMuted) {
-      onUnmute();
-    } else {
-      onMute();
-    }
-  };
-
   if (!remoteStream) {
     return null;
   }
 
   return (
     <div>
-      <audio ref={audioRef} autoPlay controls={false} muted={isMuted} />
+      <audio ref={audioRef} autoPlay controls={false} />
       <canvas ref={canvasRef} className="w-full h-64 border rounded shadow" />
-      <button
-        onClick={handleMuteClick}
-        className="mt-2 p-2 bg-blue-500 text-white rounded"
-      >
-        {isMuted ? 'Unmute' : 'Mute'}
-      </button>
     </div>
   );
 };

--- a/src/app/context/OpenAIRealtimeWebRTC.tsx
+++ b/src/app/context/OpenAIRealtimeWebRTC.tsx
@@ -90,16 +90,6 @@ interface OpenAIRealtimeWebRTCContextType {
    * @param response - The response object to be sent.
    */
   createResponse: (response?: ResponseCreateBody) => void;
-
-  /**
-   * Mutes the audio for a specific session.
-   */
-  muteSessionAudio: () => void;
-
-  /**
-   * Unmutes the audio for a specific session.
-   */
-  unmuteSessionAudio: () => void;
 }
 
 // Create the OpenAI Realtime WebRTC context
@@ -848,18 +838,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
     sendClientEvent(commitEvent);
   };
 
-  const muteSessionAudio = (): void => {
-    dispatch({
-      type: SessionActionType.MUTE_SESSION_AUDIO,
-    });
-  };
-
-  const unmuteSessionAudio = (): void => {
-    dispatch({
-      type: SessionActionType.UNMUTE_SESSION_AUDIO,
-    });
-  };
-
   /**
    * Utility function to properly cleanup WebRTC resources
    */
@@ -929,8 +907,6 @@ export const OpenAIRealtimeWebRTCProvider: React.FC<
         sendAudioChunk,
         commitAudioBuffer,
         createResponse,
-        muteSessionAudio,
-        unmuteSessionAudio,
       }}
     >
       {children}


### PR DESCRIPTION
BREAKING CHANGE: Audio control functionality has been removed from WebRTC context
and WebRTCPlayer component. This will be replaced with dedicated audio control 
components.

- Remove mute/unmute methods from WebRTC context
- Simplify WebRTCPlayer to handle only stream playback
- Update Chat component to remove audio control dependencies